### PR TITLE
Apply options dialog Interval property immediately

### DIFF
--- a/VSOStatusInspector.Package/EventArgs/OptionsChangedEventArgs.cs
+++ b/VSOStatusInspector.Package/EventArgs/OptionsChangedEventArgs.cs
@@ -1,0 +1,5 @@
+namespace VSOStatusInspector {
+    public class OptionsChangedEventArgs : System.EventArgs {
+        public double Interval { get; set; }
+    }
+}

--- a/VSOStatusInspector.Package/VSOStatusInspector.Package.csproj
+++ b/VSOStatusInspector.Package/VSOStatusInspector.Package.csproj
@@ -131,6 +131,7 @@
     </COMReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EventArgs\OptionsChangedEventArgs.cs" />
     <Compile Include="Guids.cs" />
     <Compile Include="NativeMethods.cs" />
     <Compile Include="VSOStatusInspectorOptions.cs">

--- a/VSOStatusInspector.Package/VSOStatusInspectorOptions.cs
+++ b/VSOStatusInspector.Package/VSOStatusInspectorOptions.cs
@@ -19,5 +19,20 @@ namespace VSOStatusInspector
             get { return _interval; }
             set { _interval = value; }
         }
+
+        protected override void OnApply(PageApplyEventArgs e)
+        {
+            base.OnApply(e);
+            if (OnOptionsChanged != null)
+            {
+                var optionsEventArg = new OptionsChangedEventArgs
+                {
+                    Interval = Interval,
+                };
+                OnOptionsChanged(this, optionsEventArg);
+            }
+        }
+
+        public event EventHandler<OptionsChangedEventArgs> OnOptionsChanged;
     }
 }


### PR DESCRIPTION
Implemented OptionsChanged event+handler to update the timer interval immediately rather than waiting for a VS restart.